### PR TITLE
fixed street_2 to street2 because .underscore doesn't underscore numbers

### DIFF
--- a/lib/six_saferpay/models/address.rb
+++ b/lib/six_saferpay/models/address.rb
@@ -8,7 +8,7 @@ module SixSaferpay
                   :gender,
                   :legal_form,
                   :street,
-                  :street_2,
+                  :street2,
                   :zip,
                   :city,
                   :country_subdevision_code,
@@ -25,7 +25,7 @@ module SixSaferpay
                   gender: nil,
                   legal_form: nil,
                   street: nil,
-                  street_2: nil,
+                  street2: nil,
                   zip: nil,
                   city: nil,
                   country_subdevision_code: nil,
@@ -40,7 +40,7 @@ module SixSaferpay
       @gender = gender
       @legal_form = legal_form
       @street = street
-      @street_2 = street_2
+      @street2 = street2
       @zip = zip
       @city = city
       @country_subdevision_code = country_subdevision_code
@@ -58,7 +58,7 @@ module SixSaferpay
       hash.merge!(gender: @gender) if @gender
       hash.merge!(legal_form: @legal_form) if @legal_form
       hash.merge!(street: @street) if @street
-      hash.merge!(street_2: @street_2) if @street_2.present?
+      hash.merge!(street2: @street2) if @street2.present?
       hash.merge!(zip: @zip) if @zip
       hash.merge!(city: @city) if @city
       hash.merge!(country_subdevision_code: @country_subdevision_code) if @country_subdevision_code

--- a/spec/fabrics/six_saferpay/models/addresses.rb
+++ b/spec/fabrics/six_saferpay/models/addresses.rb
@@ -7,7 +7,7 @@ SpinningWheel.define do
     gender { 'COMPANY' }
     legal_form { 'AG' }
     street { 'Bakerstreet 32' }
-    street_2 { 'Stewart House' }
+    street2 { 'Stewart House' }
     zip { '8000' }
     city { 'Zurich' }
     country_subdevision_code { 'ZH' }

--- a/spec/six_saferpay/models/address_spec.rb
+++ b/spec/six_saferpay/models/address_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SixSaferpay::Address do
       company: subject.company,
       legal_form: subject.legal_form,
       street: subject.street,
-      street_2: subject.street_2,
+      street2: subject.street2,
       gender: subject.gender,
       zip: subject.zip,
       city: subject.city,
@@ -29,7 +29,7 @@ RSpec.describe SixSaferpay::Address do
     end
   end
 
-  context 'when street_2 is an empty string', :focus do
+  context 'when street2 is an empty string', :focus do
     let(:address) do
       SixSaferpay::Address.new(
         first_name: subject.first_name,
@@ -38,7 +38,7 @@ RSpec.describe SixSaferpay::Address do
         company: subject.company,
         legal_form: subject.legal_form,
         street: subject.street,
-        street_2: "",
+        street2: "",
         gender: subject.gender,
         zip: subject.zip,
         city: subject.city,
@@ -50,7 +50,7 @@ RSpec.describe SixSaferpay::Address do
     end
 
     it 'is not added to the hash' do
-      expect(address.to_hash.keys).not_to include(:street_2)
+      expect(address.to_hash.keys).not_to include(:street2)
     end
   end
 end


### PR DESCRIPTION
```
[2] pry(main)> "Street2".to_s.underscore
=> "street2"
```