### PR TITLE
allow CaptureResponse date field to be nil

### DIFF
--- a/lib/six_saferpay/api/six_transaction/responses/capture_response.rb
+++ b/lib/six_saferpay/api/six_transaction/responses/capture_response.rb
@@ -12,7 +12,7 @@ module SixSaferpay
       def initialize(response_header: ,
                     capture_id: nil,
                     status: ,
-                    date: ,
+                    date: nil,
                     invoice: nil)
         @response_header = SixSaferpay::ResponseHeader.new(**response_header.to_h) if response_header
         @capture_id = capture_id


### PR DESCRIPTION
When payment method paydirekt is used and the capture is in state pending then the date field is not set.

In the documentation https://saferpay.github.io/jsonapi/index.html#Payment_v1_Transaction_Capture they say "Date and time of capture. Not set if the capture state is pending."